### PR TITLE
Adding static build process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ SET(CMAKE_RELEASE_PREFIX "")
 
 SET(USE_SYSTEM_SUITESPARSE ON CACHE BOOL "Use system SuiteSparse.")
 SET(USE_SYSTEM_EIGEN3 ON CACHE BOOL "Use system Eigen3.")
+SET(KLUSOLVE_LIB_TYPE "SHARED" CACHE STRING "Library type (SHARED or STATIC)")
+SET_PROPERTY(CACHE KLUSOLVE_LIB_TYPE PROPERTY STRINGS SHARED STATIC)
 
 string(FIND ${CMAKE_SYSTEM_PROCESSOR} "arm" IS_ARM_PROCESSOR)
 
@@ -122,13 +124,8 @@ if (USE_SYSTEM_SUITESPARSE)
         endif()
     endif()
 
-    # add_library(klusolve SHARED ${KLUSOLVE_SRC} src/klusolvex.def)
-    if (DEFINED ENV{KLU_AS_STATIC})
-        add_library(klusolve STATIC ${KLUSOLVE_SRC} src/klusolvex.def)
-    else()
-        add_library(klusolve SHARED ${KLUSOLVE_SRC} src/klusolvex.def)
-    endif()
-
+    add_library(klusolve ${KLUSOLVE_LIB_TYPE} ${KLUSOLVE_SRC} src/klusolvex.def)
+    
     target_link_libraries(klusolve ${KLU_LIBRARIES})
     include_directories(${SUITESPARSE_INCLUDE_DIR})
 else ()
@@ -270,11 +267,7 @@ else ()
 
     SET(SUITESPARSE_SRC "${SUITESPARSE_DIR}/SuiteSparse_config/SuiteSparse_config.c" ${COLAMD_GLOBAL} ${AMD_GLOBAL})
     
-    if (DEFINED ENV{KLU_AS_STATIC})
-        add_library(klusolve STATIC ${KLU_OBJS} ${SUITESPARSE_OBJS} ${SUITESPARSE_SRC} ${KLUSOLVE_SRC} src/klusolvex.def)
-    else()
-        add_library(klusolve SHARED ${KLU_OBJS} ${SUITESPARSE_OBJS} ${SUITESPARSE_SRC} ${KLUSOLVE_SRC} src/klusolvex.def)
-    endif()
+    add_library(klusolve ${KLUSOLVE_LIB_TYPE} ${KLU_OBJS} ${SUITESPARSE_OBJS} ${SUITESPARSE_SRC} ${KLUSOLVE_SRC} src/klusolvex.def)
 
     target_link_libraries(klusolve PUBLIC metis)
     include_directories(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,13 @@ if (USE_SYSTEM_SUITESPARSE)
         endif()
     endif()
 
-    add_library(klusolve SHARED ${KLUSOLVE_SRC} src/klusolvex.def)
+    # add_library(klusolve SHARED ${KLUSOLVE_SRC} src/klusolvex.def)
+    if (DEFINED ENV{KLU_AS_STATIC})
+        add_library(klusolve STATIC ${KLUSOLVE_SRC} src/klusolvex.def)
+    else()
+        add_library(klusolve SHARED ${KLUSOLVE_SRC} src/klusolvex.def)
+    endif()
+
     target_link_libraries(klusolve ${KLU_LIBRARIES})
     include_directories(${SUITESPARSE_INCLUDE_DIR})
 else ()
@@ -263,7 +269,12 @@ else ()
     endif()
 
     SET(SUITESPARSE_SRC "${SUITESPARSE_DIR}/SuiteSparse_config/SuiteSparse_config.c" ${COLAMD_GLOBAL} ${AMD_GLOBAL})
-    add_library(klusolve SHARED ${KLU_OBJS} ${SUITESPARSE_OBJS} ${SUITESPARSE_SRC} ${KLUSOLVE_SRC} src/klusolvex.def)
+    
+    if (DEFINED ENV{KLU_AS_STATIC})
+        add_library(klusolve STATIC ${KLU_OBJS} ${SUITESPARSE_OBJS} ${SUITESPARSE_SRC} ${KLUSOLVE_SRC} src/klusolvex.def)
+    else()
+        add_library(klusolve SHARED ${KLU_OBJS} ${SUITESPARSE_OBJS} ${SUITESPARSE_SRC} ${KLUSOLVE_SRC} src/klusolvex.def)
+    endif()
 
     target_link_libraries(klusolve PUBLIC metis)
     include_directories(

--- a/HOWTOBUILD.MD
+++ b/HOWTOBUILD.MD
@@ -1,17 +1,19 @@
 # How to build
 
-For static build, export `KLU_AS_STATIC`. e.g.:
-```
-export KLU_AS_STATIC=TRUE
-```
 
-## In shell-based enviroments (Linux and MacOs)
+Definitions:
+
+- `USE_SYSTEM_SUITESPARSE`: If "OFF" cmake will download the SuiteSparse. If "ON" cmake will use your system's installation if available. Default: "ON".
+- `USE_SYSTEM_EIGEN3`: If "OFF" cmake will download the Eigen3. If "ON" cmake will use your system's installation if available. Default: "ON".
+- `KLUSOLVE_LIB_TYPE`: If "SHARED" will compile the KLUSolveX as a shared library. If "STATIC" cmake will compile as static library. Default: "SHARED".
+
+## Examples for shell-based enviroments (Linux and MacOs)
 ### x64 (64-bits)
 ```shell
 #../klusolve
 mkdir build
 cd build
-cmake -DUSE_SYSTEM_SUITESPARSE=OFF -DUSE_SYSTEM_EIGEN3=OFF ..
+cmake -DUSE_SYSTEM_SUITESPARSE=OFF -DUSE_SYSTEM_EIGEN3=OFF -DKLUSOLVE_LIB_TYPE=STATIC .. 
 cmake --build . --config Release
 ```
 

--- a/HOWTOBUILD.MD
+++ b/HOWTOBUILD.MD
@@ -1,0 +1,25 @@
+# How to build
+
+For static build, export `KLU_AS_STATIC`. e.g.:
+```
+export KLU_AS_STATIC=TRUE
+```
+
+## In shell-based enviroments (Linux and MacOs)
+### x64 (64-bits)
+```shell
+#../klusolve
+mkdir build
+cd build
+cmake -DUSE_SYSTEM_SUITESPARSE=OFF -DUSE_SYSTEM_EIGEN3=OFF ..
+cmake --build . --config Release
+```
+
+### x84 (32-bits)
+```shell
+#../klusolve
+mkdir build
+cd build
+cmake -DUSE_SYSTEM_SUITESPARSE=OFF -DUSE_SYSTEM_EIGEN3=OFF -DCMAKE_CXX_COMPILER_ARG1=-m32 -DCMAKE_C_COMPILER_ARG1=-m32 ..
+cmake --build . --config Release
+```


### PR DESCRIPTION
This PR adds instructions on how to compile KLUsolveX as a static library.
The changes do not impact the current build process.
This PR is related to https://github.com/dss-extensions/dss_capi/issues/110